### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ script:
   - PYTHONPATH=$(pwd) pylint auth_server
   # TODO pasar el linter por todas las pruebas con pylint tests/*.py
   - PYTHONPATH=$(pwd) pylint tests/test_auth_server.py
-  - coverage run --source auth_server -m pytest
+  - python -m pytest --cov=./auth_server
   # TODO subir el threshold a medida que madure el proyecto
   - coverage report --fail-under=31
+  - codecov
   - docker-compose build
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - python -m pytest
   - PYTHONPATH=$(pwd) pylint auth_server
+  # TODO pasar el linter por todas las pruebas con pylint tests/*.py
   - PYTHONPATH=$(pwd) pylint tests/test_auth_server.py
+  - coverage run --source auth_server -m pytest
+  # TODO subir el threshold a medida que madure el proyecto
+  - coverage report --fail-under=31
   - docker-compose build
 
 before_deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/chotuve-grupo10/chotuve-application-server.git@55270f3bc1c17ae6ac4c386766a1310820032bf4#egg=app_server
+-e git+https://github.com/chotuve-grupo10/chotuve-application-server.git@5d18388f5cb2f6d261171b25173c30c8394d280c#egg=app_server
 astroid==2.4.1
 attrs==19.3.0
 CacheControl==0.12.6
@@ -6,6 +6,7 @@ cachetools==4.1.0
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
+codecov==2.1.3
 coverage==5.1
 entrypoints==0.3
 firebase-admin==4.3.0
@@ -52,6 +53,7 @@ pylint==2.5.0
 pyparsing==2.4.7
 pyrsistent==0.16.0
 pytest==5.4.1
+pytest-cov==2.8.1
 pytz==2020.1
 PyYAML==5.3.1
 req==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/chotuve-grupo10/chotuve-application-server.git@55270f3bc1c17ae6ac4c386766a1310820032bf4#egg=app_server
 astroid==2.4.1
 attrs==19.3.0
 CacheControl==0.12.6
@@ -5,7 +6,10 @@ cachetools==4.1.0
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
+coverage==5.1
+entrypoints==0.3
 firebase-admin==4.3.0
+flake8==3.7.9
 flasgger==0.9.4
 Flask==1.1.2
 google-api-core==1.17.0
@@ -27,6 +31,7 @@ itsdangerous==1.1.0
 Jinja2==2.11.2
 jsonschema==3.2.0
 lazy-object-proxy==1.4.3
+loggly-python-handler==1.0.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==0.8.4
@@ -40,6 +45,8 @@ py==1.8.1
 py-postgresql==1.2.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
+pycodestyle==2.5.0
+pyflakes==2.1.1
 PyJWT==1.7.1
 pylint==2.5.0
 pyparsing==2.4.7
@@ -47,7 +54,9 @@ pyrsistent==0.16.0
 pytest==5.4.1
 pytz==2020.1
 PyYAML==5.3.1
+req==1.0.0
 requests==2.23.0
+requests-futures==1.0.0
 rsa==4.0
 simplejson==3.17.0
 six==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e git+https://github.com/chotuve-grupo10/chotuve-application-server.git@5d18388f5cb2f6d261171b25173c30c8394d280c#egg=app_server
 astroid==2.4.1
 attrs==19.3.0
 CacheControl==0.12.6


### PR DESCRIPTION
Closes #14
1Se agrega análisis de cobertura de código en las pruebas. Se settea un threshold inicial de 31% para evitar que falle prematuramente el build, con la expectativa de aumentar el umbral progresivamente hasta no menos de 80% para el próximo milestone.
Además, se modifica el pipeline de CI para correr primero el linter, suponiendo que correr las pruebas con análisis de cobertura va a tardar más y es preferible que si el build va a fallar, lo haga lo antes posible.