### PR TITLE
Unir registracion firebase con login

### DIFF
--- a/auth_server/__init__.py
+++ b/auth_server/__init__.py
@@ -19,7 +19,7 @@ def create_app(test_config=None, db_connection=None):
 	app = Flask(__name__, instance_relative_config=True)
 
 	app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
-	app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
+	app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 	app.db = db_connection or SQLAlchemy(app)
 
 	parameters = urlparse(os.environ.get('DATABASE_URL'))

--- a/auth_server/__init__.py
+++ b/auth_server/__init__.py
@@ -8,14 +8,19 @@ from flasgger import Swagger
 from flasgger import swag_from
 from flask_cors import CORS
 import simplejson as json
+from flask_sqlalchemy import SQLAlchemy
 from auth_server.authentication import authentication_bp
 from auth_server.users import users_bp
 from auth_server.db_functions import initialize_db
 from auth_server.token_functions import *
 
-def create_app(test_config=None):
+def create_app(test_config=None, db_connection=None):
 	# create and configure the app
 	app = Flask(__name__, instance_relative_config=True)
+
+	app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+	app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
+	app.db = db_connection or SQLAlchemy(app)
 
 	parameters = urlparse(os.environ.get('DATABASE_URL'))
 	username = parameters.username

--- a/auth_server/authentication.py
+++ b/auth_server/authentication.py
@@ -43,8 +43,6 @@ def _register_user():
     user_persistence = UserPersistence(current_app.db)
     user_persistence.save(user)
     result = {'Registration': 'Successfully registered new user with email {0}'.format(user.email)}
-  #	with current_app.app_context():
-  #		result, status_code = insert_local_user_into_users_db(current_app.client, data)
     logger.debug('User was inserted')
     return result, HTTPStatus.CREATED
   except UserAlreadyRegisteredException:

--- a/auth_server/authentication.py
+++ b/auth_server/authentication.py
@@ -1,4 +1,5 @@
 import logging
+from http import HTTPStatus
 import firebase_admin
 from firebase_admin import credentials
 from firebase_admin import auth
@@ -14,7 +15,6 @@ from auth_server.token_functions import *
 from auth_server.validation_functions import *
 import auth_server.body_parser as body_parser
 from auth_server.persistence.user_persistence import UserPersistence
-from http import HTTPStatus
 from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
 from auth_server.exceptions.user_not_found_exception import UserNotFoundException
 from auth_server.model.user import User
@@ -37,67 +37,67 @@ firebase_app = firebase_admin.initialize_app(cred)
 @authentication_bp.route('/api/register/', methods=['POST'])
 @swag_from('docs/register.yml')
 def _register_user():
-  try:
-    data = request.json
-    user = body_parser.parse_regular_user(data)
-    user_persistence = UserPersistence(current_app.db)
-    user_persistence.save(user)
-    result = {'Registration': 'Successfully registered new user with email {0}'.format(user.email)}
-    logger.debug('User was inserted')
-    return result, HTTPStatus.CREATED
-  except UserAlreadyRegisteredException:
-    logger.error('This user already exists!')
-    result = {'Registration': 'This user already exists!'}
-    return result, HTTPStatus.CONFLICT
+	try:
+		data = request.json
+		user = body_parser.parse_regular_user(data)
+		user_persistence = UserPersistence(current_app.db)
+		user_persistence.save(user)
+		result = {'Registration': 'Successfully registered new user with email {0}'.format(user.email)}
+		logger.debug('User was inserted')
+		return result, HTTPStatus.CREATED
+	except UserAlreadyRegisteredException:
+		logger.error('This user already exists!')
+		result = {'Registration': 'This user already exists!'}
+		return result, HTTPStatus.CONFLICT
 
 
 @authentication_bp.route('/api/register_with_firebase/', methods=['POST'])
 @swag_from('docs/register_with_firebase.yml')
 def _register_user_using_firebase():
-  try:
-    id_token = request.headers.get('authorization', None)
-    # En claims se almacena mas informacion de usuario como mail, y datos personales
-    claims = firebase_admin.auth.verify_id_token(id_token)
-    #Si firebase no reconoce el token
-    if not claims:
-      logger.debug('Token incorrecto')
-      result = {'Register': 'invalid firebase token'}
-      status_code = 401
-    else:
-      logger.debug('Valid token')
-      result = {'Register': 'valid firebase token'}
-      status_code = 200
-      with current_app.app_context():
-        result, status_code = insert_firebase_user_into_users_db(current_app.client, claims)
-    return result, status_code
-  except ValueError as exc:
-    result = {'Register': 'Error'}
-    status_code = 401
-    logger.error(exc)
-    return result, status_code
-  except firebase_admin._auth_utils.InvalidIdTokenError as invalid_token_error:
-    result = {'Register': 'invalid token'}
-    status_code = 401
-    logger.error(invalid_token_error)
-    return result, status_code
+	try:
+		id_token = request.headers.get('authorization', None)
+		# En claims se almacena mas informacion de usuario como mail, y datos personales
+		claims = firebase_admin.auth.verify_id_token(id_token)
+		#Si firebase no reconoce el token
+		if not claims:
+			logger.debug('Token incorrecto')
+			result = {'Register': 'invalid firebase token'}
+			status_code = 401
+		else:
+			logger.debug('Valid token')
+			result = {'Register': 'valid firebase token'}
+			status_code = 200
+			with current_app.app_context():
+				result, status_code = insert_firebase_user_into_users_db(current_app.client, claims)
+		return result, status_code
+	except ValueError as exc:
+		result = {'Register': 'Error'}
+		status_code = 401
+		logger.error(exc)
+		return result, status_code
+	except firebase_admin._auth_utils.InvalidIdTokenError as invalid_token_error:
+		result = {'Register': 'invalid token'}
+		status_code = 401
+		logger.error(invalid_token_error)
+		return result, status_code
 
 @authentication_bp.route('/api/register_admin_user/', methods=['POST'])
 @cross_origin(allow_headers=['Content-Type'])
 @swag_from('docs/register_admin_user.yml')
 def _register_admin_user():
 
-  id_token = request.headers.get('authorization', None)
+	id_token = request.headers.get('authorization', None)
 
-  if is_request_from_admin_user(id_token):
-    logger.debug('Token is from admin user')
-    data = request.json
-    with current_app.app_context():
-      result, status_code = insert_admin_user_into_users_db(current_app.client, data)
-  else:
-    logger.error('Request doesnt come from admin user')
-    result, status_code = {'Error':'This request doesnt come from an admin user'}, 401
+	if is_request_from_admin_user(id_token):
+		logger.debug('Token is from admin user')
+		data = request.json
+		with current_app.app_context():
+			result, status_code = insert_admin_user_into_users_db(current_app.client, data)
+	else:
+		logger.error('Request doesnt come from admin user')
+		result, status_code = {'Error':'This request doesnt come from an admin user'}, 401
 
-  return result, status_code
+	return result, status_code
 
 ## La realidad es que no importa la red social lo que verificamos es el token de firebase.
 ## Por ahora lo dejo por si se me esta pasando algo, pero eventualmente vamos a borrar este endpoint
@@ -136,81 +136,81 @@ def _register_admin_user():
 @cross_origin(allow_headers=['Content-Type'])
 @swag_from('docs/login.yml')
 def _login_user():
-  data = request.json
-  logger.debug(data['email'])
-  with current_app.app_context():
-    result, status_code, user = get_user(current_app.client, data['email'])
-    if status_code == 200:
-      if validar_usuario(user, data['password']):
-        logger.debug('Usuario logueado con exito')
-        token = generate_auth_token(data['email'])
-        logger.debug('This is the token {0}'.format(token))
-        result = {'Token': token}
-      else:
-        logger.debug('La password es incorrecta')
-        result = {'Login': 'invalid password'}
-        status_code = 401
-  return result, status_code
-  # para cuando nos llegue la request desde Androide
-  # user_request = request.headers['AuthenticationHeader']
-  # auth = HTTPBasicAuth('taller', 'notanseguro')
-  # auth_login = '/api/login/'
-  # response_auth_server = get_auth_server_login(os.environ.get('AUTH_SERVER_URL') +
-  # 											 auth_login, auth)
-  # if response_auth_server.status_code == 200:
-  # 	# app.logger.debug('Response from auth server login is 200')
-  # 	response = {'Successful login'}
-  # 	response.status_code = 200
-  # else:
-  # 	# app.logger.debug('Response from auth server login is {0}'.
-  # 	#                  format(response_auth_server.status_code))
-  # 	response = {'Login failed'}
-  # 	response.status_code = 401
-  # current_app.logger.debug('Login was successful since it does anything at all')
-  # return {'Login': 'was successful'}
+	data = request.json
+	logger.debug(data['email'])
+	with current_app.app_context():
+		result, status_code, user = get_user(current_app.client, data['email'])
+		if status_code == 200:
+			if validar_usuario(user, data['password']):
+				logger.debug('Usuario logueado con exito')
+				token = generate_auth_token(data['email'])
+				logger.debug('This is the token {0}'.format(token))
+				result = {'Token': token}
+			else:
+				logger.debug('La password es incorrecta')
+				result = {'Login': 'invalid password'}
+				status_code = 401
+	return result, status_code
+	# para cuando nos llegue la request desde Androide
+	# user_request = request.headers['AuthenticationHeader']
+	# auth = HTTPBasicAuth('taller', 'notanseguro')
+	# auth_login = '/api/login/'
+	# response_auth_server = get_auth_server_login(os.environ.get('AUTH_SERVER_URL') +
+	# 											 auth_login, auth)
+	# if response_auth_server.status_code == 200:
+	# 	# app.logger.debug('Response from auth server login is 200')
+	# 	response = {'Successful login'}
+	# 	response.status_code = 200
+	# else:
+	# 	# app.logger.debug('Response from auth server login is {0}'.
+	# 	#                  format(response_auth_server.status_code))
+	# 	response = {'Login failed'}
+	# 	response.status_code = 401
+	# current_app.logger.debug('Login was successful since it does anything at all')
+	# return {'Login': 'was successful'}
 
 @authentication_bp.route('/api/login_with_firebase/', methods=['POST'])
 @swag_from('docs/login_with_firebase.yml')
 def _login_user_using_firebase():
-  try:
-    id_token = request.headers.get('authorization', None)
-    claims = firebase_admin.auth.verify_id_token(id_token)
-    if not claims or not claims.get('email'):
-      logger.debug('Response from auth server login is 401')
-      result = {'Login': 'invalid firebase token'}
-      status_code = 401
-      return result, status_code
+	try:
+		id_token = request.headers.get('authorization', None)
+		claims = firebase_admin.auth.verify_id_token(id_token)
+		if not claims or not claims.get('email'):
+			logger.debug('Response from auth server login is 401')
+			result = {'Login': 'invalid firebase token'}
+			status_code = 401
+			return result, status_code
 
-    user_persistence = UserPersistence(current_app.db)
-    user = None
-    try:
-      user = user_persistence.get_user_by_email(claims.get('email'))
-    except UserNotFoundException:
-      user = User(claims.get('email'), None, claims.get('name'), 'NULL', 
-              claims.get('picture'), True, False)
-      user_persistence.save(user)
+		user_persistence = UserPersistence(current_app.db)
+		user = None
+		try:
+			user = user_persistence.get_user_by_email(claims.get('email'))
+		except UserNotFoundException:
+			user = User(claims.get('email'), None, claims.get('name'), 'NULL',
+							claims.get('picture'), True, False)
+			user_persistence.save(user)
 
-    if user.is_firebase_user():
-      logger.debug('Usuario logueado con exito')
-      token = generate_auth_token(claims.get('email'))
-      logger.debug('This is the token {0}'.format(token))
-      result = {'Token': token}
-      status_code = HTTPStatus.OK
-    else:
-      logger.debug('User not registered with Firebase')
-      result = {'Login': 'user not registered with Firebase'}
-      status_code = 401
-    return result, status_code
-  except ValueError as exc:
-    result = {'Login': 'Error'}
-    status_code = 401
-    logger.error(exc)
-    return result, status_code
-  except firebase_admin._auth_utils.InvalidIdTokenError as invalid_token_error:
-    result = {'Register': str(invalid_token_error)}
-    status_code = 401
-    logger.error(invalid_token_error)
-    return result, status_code
+		if user.is_firebase_user():
+			logger.debug('Usuario logueado con exito')
+			token = generate_auth_token(claims.get('email'))
+			logger.debug('This is the token {0}'.format(token))
+			result = {'Token': token}
+			status_code = HTTPStatus.OK
+		else:
+			logger.debug('User not registered with Firebase')
+			result = {'Login': 'user not registered with Firebase'}
+			status_code = 401
+		return result, status_code
+	except ValueError as exc:
+		result = {'Login': 'Error'}
+		status_code = 401
+		logger.error(exc)
+		return result, status_code
+	except firebase_admin._auth_utils.InvalidIdTokenError as invalid_token_error:
+		result = {'Register': str(invalid_token_error)}
+		status_code = 401
+		logger.error(invalid_token_error)
+		return result, status_code
 
 
 ## Misma historia que mas arriba.
@@ -248,9 +248,9 @@ def _login_user_using_firebase():
 @authentication_bp.route('/api/validate_token/', methods=['GET'])
 @swag_from('docs/validate_token.yml')
 def _validate_token():
-  jwt_token = request.headers.get('authorization', None)
-  result, status_code = validate_token(jwt_token)
-  return result, status_code
+	jwt_token = request.headers.get('authorization', None)
+	result, status_code = validate_token(jwt_token)
+	return result, status_code
 
 
 #### Updating methods ###
@@ -258,9 +258,9 @@ def _validate_token():
 @authentication_bp.route('/api/forgot_password/', methods=['GET'])
 @swag_from('docs/forgot_password.yml')
 def _forgot_password():
-  return {}
+	return {}
 
 @authentication_bp.route('/api/reset_password/', methods=['GET'])
 @swag_from('docs/reset_password.yml')
 def _reset_password():
-  return {}
+	return {}

--- a/auth_server/body_parser.py
+++ b/auth_server/body_parser.py
@@ -1,9 +1,9 @@
 from auth_server.model.user import User
 
 def parse_regular_user(body):
-  email = body['email']
-  full_name = body['full name']
-  phone_number = body['phone number']
-  profile_picture = body['profile picture']
-  password = body['password']
-  return User(email, password, full_name, phone_number, profile_picture, False, False)
+	email = body['email']
+	full_name = body['full name']
+	phone_number = body['phone number']
+	profile_picture = body['profile picture']
+	password = body['password']
+	return User(email, password, full_name, phone_number, profile_picture, False, False)

--- a/auth_server/body_parser.py
+++ b/auth_server/body_parser.py
@@ -1,0 +1,9 @@
+from auth_server.model.user import User
+
+def parse_regular_user(body):
+  email = body['email']
+  full_name = body['full name']
+  phone_number = body['phone number']
+  profile_picture = body['profile picture']
+  password = body['password']
+  return User(email, password, full_name, phone_number, profile_picture, False, False)

--- a/auth_server/db_functions.py
+++ b/auth_server/db_functions.py
@@ -53,44 +53,6 @@ def table_exists(client, table_name):
 		logger.debug('Table {0} does not exists'.format(table_name))
 		return False
 
-def insert_local_user_into_users_db(client, user_information):
-
-	# with current_app.app_context():
-	client = current_app.client
-	sal = random_string(6)
-	pimienta = random_string(1)
-	cursor = client.cursor()
-	try:
-		cursor.execute(
-			"""INSERT INTO Users(email,full_name,phone_number,profile_picture,hash,salt,firebase_user,admin_user)
-				VALUES('{email}','{full_name}','{phone_number}','{profile_picture}','{hash}','{salt}','{firebase_user}','{admin_user}');"""
-					.format(email=user_information['email'],
-					full_name=user_information['full name'],
-					phone_number=user_information['phone number'],
-					profile_picture=user_information['profile picture'],
-					hash=hashlib.sha512((user_information['password']+sal+pimienta).encode('utf-8')).hexdigest(),
-					salt=sal,
-					firebase_user='0',
-					admin_user='0'))
-
-		client.commit()
-		logger.debug('Successfully registered new user with email {0}'.format(user_information['email']))
-		result = {'Registration': 'Successfully registered new user with email {0}'.format(user_information['email'])}
-		status_code = 201		# Created
-	except psql_errors.UniqueViolation:
-		client.rollback()
-		logger.error('This user already exists!')
-		result = {'Registration': 'This user already exists!'}
-		status_code = 409		# Conflict
-	except Exception as e:
-		client.rollback()
-		logger.error('Error {e}. Could not insert new user'.format(e=e))
-		result = {'Registration': 'Error {e}. Could not insert new user'.format(e=e)}
-		status_code = 500
-
-	cursor.close()
-	return result, status_code
-
 def insert_admin_user_into_users_db(client, user_information):
 
 	# with current_app.app_context():

--- a/auth_server/docs/login_with_firebase.yml
+++ b/auth_server/docs/login_with_firebase.yml
@@ -1,4 +1,5 @@
-Recibe una solicitud de login utilizando Firebase
+Recibe una solicitud de login utilizando Firebase. Si el usuario no está registrado, 
+se lo registra automáticamente
 ---
 components:
   securitySchemes:

--- a/auth_server/exceptions/user_already_registered_exception.py
+++ b/auth_server/exceptions/user_already_registered_exception.py
@@ -1,0 +1,2 @@
+class UserAlreadyRegisteredException(Exception):
+  pass

--- a/auth_server/exceptions/user_not_found_exception.py
+++ b/auth_server/exceptions/user_not_found_exception.py
@@ -1,0 +1,2 @@
+class UserNotFoundException(Exception):
+  pass

--- a/auth_server/model/base.py
+++ b/auth_server/model/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()

--- a/auth_server/model/user.py
+++ b/auth_server/model/user.py
@@ -25,8 +25,13 @@ class User(Base):
     self.profile_picture = profile_picture
     self.hash = hashlib.sha512((password + sal + pimienta).encode('utf-8')).hexdigest() if password else 0
     self.salt = sal if password else 0
-    self.firebase_user = 1 if is_firebase_user else 0
-    self.admin_user = 1 if is_admin_user else 0
+    self.firebase_user = '1' if is_firebase_user else '0'
+    self.admin_user = '1' if is_admin_user else '0'
     
   def is_firebase_user(self):
-    return self.firebase_user == 1
+    return self.firebase_user == '1'
+
+  def __repr__(self):
+    return """<User email={0} full_name={1} phone_number={2} profile_picture={3} 
+        firebase={4} admin={5}""".format(self.email, self.full_name, self.phone_number, 
+        self.profile_picture, str(self.is_firebase_user()), self.admin_user)

--- a/auth_server/model/user.py
+++ b/auth_server/model/user.py
@@ -23,9 +23,10 @@ class User(Base):
     self.full_name = full_name
     self.phone_number = phone_number
     self.profile_picture = profile_picture
-    self.hash = hashlib.sha512((password + sal + pimienta).encode('utf-8')).hexdigest()
-    self.salt = sal
+    self.hash = hashlib.sha512((password + sal + pimienta).encode('utf-8')).hexdigest() if password else 0
+    self.salt = sal if password else 0
     self.firebase_user = 1 if is_firebase_user else 0
     self.admin_user = 1 if is_admin_user else 0
     
-
+  def is_firebase_user(self):
+    return self.firebase_user == 1

--- a/auth_server/model/user.py
+++ b/auth_server/model/user.py
@@ -1,0 +1,31 @@
+import hashlib
+from auth_server.random_string import *
+from sqlalchemy import Column, Integer, String
+from auth_server.model.base import Base
+
+class User(Base):
+  __tablename__ = 'users'
+
+  email = Column(String, primary_key = True)
+  full_name = Column(String)
+  phone_number = Column(String)
+  profile_picture = Column(String)
+  hash = Column(String)
+  salt = Column(String)
+  firebase_user = Column(String)
+  admin_user = Column(String)
+
+  def __init__(self, email, password, full_name, phone_number, profile_picture, \
+      is_firebase_user, is_admin_user):
+    sal = random_string(6)
+    pimienta = random_string(1)
+    self.email = email
+    self.full_name = full_name
+    self.phone_number = phone_number
+    self.profile_picture = profile_picture
+    self.hash = hashlib.sha512((password + sal + pimienta).encode('utf-8')).hexdigest()
+    self.salt = sal
+    self.firebase_user = 1 if is_firebase_user else 0
+    self.admin_user = 1 if is_admin_user else 0
+    
+

--- a/auth_server/persistence/user_persistence.py
+++ b/auth_server/persistence/user_persistence.py
@@ -6,7 +6,7 @@ class UserPersistence():
     self.db = db_connection
   
   def save(self, user):
-    if self.db.query(User).get(user.email) is not None:
+    if self.db.session.query(User).get(user.email) is not None:
       raise UserAlreadyRegisteredException
-    self.db.add(user)
-    self.db.commit()
+    self.db.session.add(user)
+    self.db.session.commit()

--- a/auth_server/persistence/user_persistence.py
+++ b/auth_server/persistence/user_persistence.py
@@ -1,4 +1,5 @@
 from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
+from auth_server.exceptions.user_not_found_exception import UserNotFoundException
 from auth_server.model.user import User
 
 class UserPersistence():
@@ -10,3 +11,9 @@ class UserPersistence():
       raise UserAlreadyRegisteredException
     self.db.session.add(user)
     self.db.session.commit()
+  
+  def get_user_by_email(self, email):
+    user = self.db.session.query(User).get(email)
+    if user is None:
+      raise UserNotFoundException
+    return user

--- a/auth_server/persistence/user_persistence.py
+++ b/auth_server/persistence/user_persistence.py
@@ -1,0 +1,12 @@
+from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
+from auth_server.model.user import User
+
+class UserPersistence():
+  def __init__(self, db_connection):
+    self.db = db_connection
+  
+  def save(self, user):
+    if self.db.query(User).get(user.email) is not None:
+      raise UserAlreadyRegisteredException
+    self.db.add(user)
+    self.db.commit()

--- a/db/migrations.py
+++ b/db/migrations.py
@@ -1,0 +1,15 @@
+create_table_users = """CREATE TABLE Users (
+						email VARCHAR(255) PRIMARY KEY ,
+						full_name VARCHAR(255) NOT NULL,
+						phone_number VARCHAR(255),
+						profile_picture VARCHAR(255),
+						hash VARCHAR(255) NOT NULL,
+						salt VARCHAR(255) NOT NULL,
+						firebase_user VARCHAR(1) NOT NULL,
+						admin_user VARCHAR(1) NOT NULL);"""
+
+
+def all_migrations():
+  migration_list = []
+  migration_list.append(create_table_users)
+  return migration_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ flake8==3.7.9
 flasgger==0.9.4
 Flask==1.1.2
 Flask-Cors==3.0.8
+Flask-SQLAlchemy==2.4.3
+freezegun==0.3.15
 google-api-core==1.17.0
 google-api-python-client==1.8.3
 google-auth==1.14.3
@@ -39,6 +41,7 @@ mistune==0.8.4
 more-itertools==8.2.0
 msgpack==1.0.0
 packaging==20.3
+pg8000==1.15.3
 pluggy==0.13.1
 protobuf==3.11.3
 psycopg2==2.8.5
@@ -54,14 +57,20 @@ pyparsing==2.4.7
 pyrsistent==0.16.0
 pytest==5.4.1
 pytest-cov==2.8.1
+pytest-pgsql==1.1.2
+python-dateutil==2.8.1
 pytz==2020.1
 PyYAML==5.3.1
 req==1.0.0
 requests==2.23.0
 requests-futures==1.0.0
 rsa==4.0
+scramp==1.2.0
 simplejson==3.17.0
 six==1.14.0
+SQLAlchemy==1.3.17
+testing.common.database==2.0.3
+testing.postgresql==1.3.0
 toml==0.10.1
 typed-ast==1.4.1
 uritemplate==3.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,14 @@
 
 import pytest
 from auth_server import create_app
+from flask_sqlalchemy import SQLAlchemy as sqla
+import db.migrations as migrations
 # pylint: disable=W0621	(redefined-outer-name)
 
 @pytest.fixture
 def app():
 	# db_path = tempfile.mkstemp()
-
-	app = create_app({
+	app = create_app(test_config = {
 		'TESTING': True
 	})
 
@@ -18,11 +19,28 @@ def app():
 
 	return app
 
+@pytest.fixture
+def app_with_db(postgresql_db):
+	# db_path = tempfile.mkstemp()
+	app = create_app(test_config = {
+		'TESTING': True
+	},
+    db_connection = postgresql_db)
+
+	postgresql_db.session.execute(migrations.all_migrations()[0])
+
+	with app.app_context():
+		pass
+
+	return app
 
 @pytest.fixture
 def client(app):
 	return app.test_client()
 
+@pytest.fixture
+def client_with_db(app_with_db):
+	return app_with_db.test_client()
 
 @pytest.fixture
 def runner(app):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,151 +1,187 @@
 from unittest.mock import patch
 import simplejson as json
 from auth_server.persistence.user_persistence import UserPersistence
+from auth_server.model.user import User
 # from auth_server.db_functions import insert_into_users_db
 from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
+from auth_server.exceptions.user_not_found_exception import UserNotFoundException
 
 def test_register_user_succesfully(client):
-	with patch.object(UserPersistence,'save') as mock:
-		user_information = {'email': 'this_email_should_not_be_saved@test.com',
-				'password': 'fake password',
-				'full name': 'full name',
-				'phone number': 'phone number', 
+  with patch.object(UserPersistence,'save') as mock:
+    user_information = {'email': 'this_email_should_not_be_saved@test.com',
+        'password': 'fake password',
+        'full name': 'full name',
+        'phone number': 'phone number', 
         'profile picture': 'profile picture',
-		}
+    }
 
-		result = {'Registration': 'Successfully registered new user with email {0}'.format(user_information['email'])}
+    result = {'Registration': 'Successfully registered new user with email {0}'.format(user_information['email'])}
 
-		response = client.post('/api/register/', json=user_information,
-							   follow_redirects=False)
-		value_expected = {'Registration' :
-			'Successfully registered new user with email {0}'.format(user_information['email'])}
+    response = client.post('/api/register/', json=user_information,
+                 follow_redirects=False)
+    value_expected = {'Registration' :
+      'Successfully registered new user with email {0}'.format(user_information['email'])}
 
-		assert mock.called
-		assert json.loads(response.data) == value_expected
-		assert response.status_code == 201
+    assert mock.called
+    assert json.loads(response.data) == value_expected
+    assert response.status_code == 201
 
 def test_register_user_succesfully_e2e(client_with_db):
-		user_information = {'email': 'this_email_should_not_be_saved@test.com',
-				'password': 'fake password',
-				'full name': 'full name',
-				'phone number': 'phone number', 
+    user_information = {'email': 'this_email_should_not_be_saved@test.com',
+        'password': 'fake password',
+        'full name': 'full name',
+        'phone number': 'phone number', 
         'profile picture': 'profile picture',
-		}
+    }
 
-		response = client_with_db.post('/api/register/', json=user_information,
-							   follow_redirects=False)
-		value_expected = {'Registration' :
-			'Successfully registered new user with email {0}'.format(user_information['email'])}
-		assert json.loads(response.data) == value_expected  
-		assert response.status_code == 201
+    response = client_with_db.post('/api/register/', json=user_information,
+                 follow_redirects=False)
+    value_expected = {'Registration' :
+      'Successfully registered new user with email {0}'.format(user_information['email'])}
+    assert json.loads(response.data) == value_expected  
+    assert response.status_code == 201
 
 def raise_already_registered_exception(cls, *args, **kwargs):
   raise UserAlreadyRegisteredException
 
 def test_register_user_already_registered(client):
-	with patch.object(UserPersistence,'save', new=raise_already_registered_exception) as mock:
-		user_information = {'email': 'diegote@gmail.com',
-				'password': 'fake password',
-				'full name': 'full name',
-				'phone number': 'phone number', 'profile picture': 'profile picture',
-				'hash': 'hash', 'salt': 'salt', 'firebase_user':'0', 'admin_user':'0'}
+  with patch.object(UserPersistence,'save', new=raise_already_registered_exception) as mock:
+    user_information = {'email': 'diegote@gmail.com',
+        'password': 'fake password',
+        'full name': 'full name',
+        'phone number': 'phone number', 'profile picture': 'profile picture',
+        'hash': 'hash', 'salt': 'salt', 'firebase_user':'0', 'admin_user':'0'}
 
-		response = client.post('/api/register/', json=user_information,
-							   follow_redirects=False)
-		value_expected = {'Registration' :
-			'This user already exists!'}
+    response = client.post('/api/register/', json=user_information,
+                 follow_redirects=False)
+    value_expected = {'Registration' :
+      'This user already exists!'}
 
-		assert json.loads(response.data) == value_expected
-		assert response.status_code == 409
+    assert json.loads(response.data) == value_expected
+    assert response.status_code == 409
 
 def test_login_user_succesful(client):
-	with patch('auth_server.authentication.get_user') as mock_get_user:
-		result = {}
-		status_code = 200
-		user = ('diegote@gmail.com')
-		mock_get_user.return_value = result, status_code, user
+  with patch('auth_server.authentication.get_user') as mock_get_user:
+    result = {}
+    status_code = 200
+    user = ('diegote@gmail.com')
+    mock_get_user.return_value = result, status_code, user
 
-		with patch('auth_server.authentication.validar_usuario') as mock_validar:
+    with patch('auth_server.authentication.validar_usuario') as mock_validar:
 
-			with patch('auth_server.authentication.generate_auth_token') as mock_token_generation:
-				mock_token_generation.return_value = 'THISISAFAKETOKEN'
-				user_information = {'email': 'diegote@gmail.com',
-									'password': 'fake_falopa'}
+      with patch('auth_server.authentication.generate_auth_token') as mock_token_generation:
+        mock_token_generation.return_value = 'THISISAFAKETOKEN'
+        user_information = {'email': 'diegote@gmail.com',
+                  'password': 'fake_falopa'}
 
 
-				response = client.post('/api/login/', json=user_information,
-									   follow_redirects=False)
-				value_expected = {'Token':
-								  'THISISAFAKETOKEN'}
+        response = client.post('/api/login/', json=user_information,
+                     follow_redirects=False)
+        value_expected = {'Token':
+                  'THISISAFAKETOKEN'}
 
-			mock_validar.return_value = True
-			assert mock_get_user.called
-			assert mock_validar.called
-			assert mock_token_generation.called
-			assert json.loads(response.data) == value_expected
+      mock_validar.return_value = True
+      assert mock_get_user.called
+      assert mock_validar.called
+      assert mock_token_generation.called
+      assert json.loads(response.data) == value_expected
 
 def test_login_user_not_found(client):
-	with patch('auth_server.authentication.get_user') as mock_get_user:
-		result = {'Login': 'user NOT found'}
-		status_code = 404
-		user = None
-		mock_get_user.return_value = result, status_code, user
+  with patch('auth_server.authentication.get_user') as mock_get_user:
+    result = {'Login': 'user NOT found'}
+    status_code = 404
+    user = None
+    mock_get_user.return_value = result, status_code, user
 
-		user_information = {'email': 'this_user_does_not_Exist@gmail.com',
-							'password': 'some_password'}
+    user_information = {'email': 'this_user_does_not_Exist@gmail.com',
+              'password': 'some_password'}
 
-		response = client.post('/api/login/', json=user_information,
-									   follow_redirects=False)
-		value_expected = result
+    response = client.post('/api/login/', json=user_information,
+                     follow_redirects=False)
+    value_expected = result
 
-		assert mock_get_user.called
-		assert json.loads(response.data) == value_expected
+    assert mock_get_user.called
+    assert json.loads(response.data) == value_expected
 
 def test_register_admin_user_fails_request_doesnt_come_from_admin_user(client):
-	with patch('auth_server.authentication.is_request_from_admin_user') as mock_is_request_from_admin_user:
+  with patch('auth_server.authentication.is_request_from_admin_user') as mock_is_request_from_admin_user:
 
-		mock_is_request_from_admin_user.return_value = False
+    mock_is_request_from_admin_user.return_value = False
 
-		user_information = {'email': 'this_email_should_not_be_saved@test.com',
-				'password': 'fake password',
-				'full name': 'full name',
-				'phone number': 'phone number', 'profile picture': 'profile picture'}
+    user_information = {'email': 'this_email_should_not_be_saved@test.com',
+        'password': 'fake password',
+        'full name': 'full name',
+        'phone number': 'phone number', 'profile picture': 'profile picture'}
 
-		hed = {'authorization': 'FAKETOKEN'}
+    hed = {'authorization': 'FAKETOKEN'}
 
-		response = client.post('/api/register_admin_user/', json=user_information, headers=hed,
-									   follow_redirects=False)
+    response = client.post('/api/register_admin_user/', json=user_information, headers=hed,
+                     follow_redirects=False)
 
-		value_expected = {'Error':'This request doesnt come from an admin user'}
+    value_expected = {'Error':'This request doesnt come from an admin user'}
 
-		assert mock_is_request_from_admin_user.called
-		assert json.loads(response.data) == value_expected
+    assert mock_is_request_from_admin_user.called
+    assert json.loads(response.data) == value_expected
 
 def test_register_admin_user_successfully(client):
-	with patch('auth_server.authentication.is_request_from_admin_user') as mock_is_request_from_admin_user:
+  with patch('auth_server.authentication.is_request_from_admin_user') as mock_is_request_from_admin_user:
 
-		mock_is_request_from_admin_user.return_value = True
+    mock_is_request_from_admin_user.return_value = True
 
-		with patch('auth_server.authentication.insert_admin_user_into_users_db') as mock_insert_admin_user:
+    with patch('auth_server.authentication.insert_admin_user_into_users_db') as mock_insert_admin_user:
 
-			user_information = {'email': 'test@test.com',
-					'password': 'fake password',
-					'full name': 'full name',
-					'phone number': 'phone number', 'profile picture': 'profile picture'}
+      user_information = {'email': 'test@test.com',
+          'password': 'fake password',
+          'full name': 'full name',
+          'phone number': 'phone number', 'profile picture': 'profile picture'}
 
-			hed = {'authorization': 'FAKETOKEN'}
+      hed = {'authorization': 'FAKETOKEN'}
 
-			result = {'Registration': 'Successfully registered new user with email {0}'.format(user_information['email'])}
-			status_code = 201
+      result = {'Registration': 'Successfully registered new user with email {0}'.format(user_information['email'])}
+      status_code = 201
 
-			mock_insert_admin_user.return_value = result, status_code
+      mock_insert_admin_user.return_value = result, status_code
 
-			response = client.post('/api/register_admin_user/', json=user_information, headers=hed,
-										follow_redirects=False)
+      response = client.post('/api/register_admin_user/', json=user_information, headers=hed,
+                    follow_redirects=False)
 
-			value_expected =  result
+      value_expected =  result
 
-			assert mock_is_request_from_admin_user.called
-			assert mock_insert_admin_user.called
-			assert json.loads(response.data) == value_expected
+      assert mock_is_request_from_admin_user.called
+      assert mock_insert_admin_user.called
+      assert json.loads(response.data) == value_expected
 
+def test_succesful_login_with_firebase_user_already_registered(client):
+  with patch.object(UserPersistence,'get_user_by_email') as user_persistence_mock:
+    with patch('firebase_admin.auth.verify_id_token') as firebase_mock:
+      firebase_mock.return_value = {'email': 'aa@gmail.com'}
+      user_persistence_mock.return_value = User('aa@gmail.com', '', 'Tito', '', '', True, False)
+      response = client.post('/api/login_with_firebase/', json={}, 
+                    headers={'authorization': 'FAKETOKEN'}, follow_redirects=False)
+      
+      assert json.loads(response.data).get('Token')
+
+def test_login_with_firebase_user_registered_as_password_user(client):
+  with patch.object(UserPersistence,'get_user_by_email') as user_persistence_mock:
+    with patch('firebase_admin.auth.verify_id_token') as firebase_mock:
+      firebase_mock.return_value = {'email': 'aa@gmail.com'}
+      user_persistence_mock.return_value = User('aa@gmail.com', '', 'Tito', '', '', False, False)
+      response = client.post('/api/login_with_firebase/', json={}, 
+                    headers={'authorization': 'FAKETOKEN'}, follow_redirects=False)
+      
+      assert json.loads(response.data) == {'Login': 'user not registered with Firebase'}
+
+def raise_not_found_exception(cls, *args, **kwargs):
+  raise UserNotFoundException
+
+def test_succesful_login_with_firebase_user_not_registered(client):
+  with patch.object(UserPersistence,'save') as save_user:
+    with patch.object(UserPersistence,'get_user_by_email', new=raise_not_found_exception) as get_user:
+      with patch('firebase_admin.auth.verify_id_token') as firebase_mock:
+        firebase_mock.return_value = {'email': 'aa@gmail.com'}
+
+        response = client.post('/api/login_with_firebase/', json={}, 
+                      headers={'authorization': 'FAKETOKEN'}, follow_redirects=False)
+
+        assert save_user.called        
+        assert json.loads(response.data).get('Token')

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,7 @@
+from auth_server.model.user import User
+
+def test_is_firebase():
+  user_firebase = User('aa@gmail.com', 'pa$$word', 'John Doe', '1111', 'NULL', True, False)
+  user_not_firebase = User('aa@gmail.com', 'pa$$word', 'John Doe', '1111', 'NULL', False, False)
+  assert user_firebase.is_firebase_user()
+  assert not user_not_firebase.is_firebase_user()

--- a/tests/test_user_persistence.py
+++ b/tests/test_user_persistence.py
@@ -9,7 +9,7 @@ def test_save_password_user(postgresql_db):
   create_all(session)
   assert query_first_user(session) is None
   user_to_save = User('aa@gmail.com', 'aaa', 'John Doe', '555-5555', None, False, False)
-  sut = UserPersistence(session)
+  sut = UserPersistence(postgresql_db)
   sut.save(user_to_save)
   row = query_first_user(session)
   assert row is not None
@@ -21,7 +21,7 @@ def test_save_existent_user(postgresql_db):
   session = postgresql_db.session
   create_all(session)
   saved_user = User('aa@gmail.com', 'bbb', 'Jane Doe', '111-1111', None, False, False)
-  sut = UserPersistence(session)
+  sut = UserPersistence(postgresql_db)
   sut.save(saved_user)
   with pytest.raises(UserAlreadyRegisteredException):
     user_to_save = User('aa@gmail.com', 'aaa', 'John Doe', '555-5555', None, False, False)

--- a/tests/test_user_persistence.py
+++ b/tests/test_user_persistence.py
@@ -1,6 +1,7 @@
 import db.migrations
 import pytest
 from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
+from auth_server.exceptions.user_not_found_exception import UserNotFoundException
 from auth_server.model.user import User
 from auth_server.persistence.user_persistence import UserPersistence
 
@@ -27,6 +28,24 @@ def test_save_existent_user(postgresql_db):
     user_to_save = User('aa@gmail.com', 'aaa', 'John Doe', '555-5555', None, False, False)
     sut.save(user_to_save)
 
+def test_retrieve_existent_user(postgresql_db):
+  session = postgresql_db.session
+  create_all(session)
+  insert_test_user(session)
+  sut = UserPersistence(postgresql_db)
+  user = sut.get_user_by_email('test@test.com')
+  assert user.email == 'test@test.com'
+  assert user.full_name == 'Test User'
+  assert user.phone_number == '444-4444'
+#  assert user.is_admin() == False
+#  assert user.is_firebase_user() == False
+
+def test_retrieve_inexistent_user(postgresql_db):
+  session = postgresql_db.session
+  create_all(session)
+  sut = UserPersistence(postgresql_db)
+  with pytest.raises(UserNotFoundException):
+    user = sut.get_user_by_email('aa@gmail.com')
 
 def create_all(conn):
   migrations = db.migrations.all_migrations()
@@ -35,4 +54,8 @@ def create_all(conn):
 
 def query_first_user(conn):
     return conn.execute("SELECT email, full_name, phone_number FROM users").fetchone()
-    
+
+def insert_test_user(conn):
+    conn.execute("""INSERT INTO users (email, full_name, phone_number, profile_picture,
+						hash, salt, firebase_user, admin_user) VALUES ('test@test.com', 'Test User',
+            '444-4444', null, 'xxxxx', 'xxxxx', '0', '0')""")

--- a/tests/test_user_persistence.py
+++ b/tests/test_user_persistence.py
@@ -1,0 +1,38 @@
+import db.migrations
+import pytest
+from auth_server.exceptions.user_already_registered_exception import UserAlreadyRegisteredException
+from auth_server.model.user import User
+from auth_server.persistence.user_persistence import UserPersistence
+
+def test_save_password_user(postgresql_db):
+  session = postgresql_db.session
+  create_all(session)
+  assert query_first_user(session) is None
+  user_to_save = User('aa@gmail.com', 'aaa', 'John Doe', '555-5555', None, False, False)
+  sut = UserPersistence(session)
+  sut.save(user_to_save)
+  row = query_first_user(session)
+  assert row is not None
+  assert row[0] == 'aa@gmail.com'
+  assert row[1] == 'John Doe'
+  assert row[2] == '555-5555'
+
+def test_save_existent_user(postgresql_db):
+  session = postgresql_db.session
+  create_all(session)
+  saved_user = User('aa@gmail.com', 'bbb', 'Jane Doe', '111-1111', None, False, False)
+  sut = UserPersistence(session)
+  sut.save(saved_user)
+  with pytest.raises(UserAlreadyRegisteredException):
+    user_to_save = User('aa@gmail.com', 'aaa', 'John Doe', '555-5555', None, False, False)
+    sut.save(user_to_save)
+
+
+def create_all(conn):
+  migrations = db.migrations.all_migrations()
+  for migration in migrations:
+    conn.execute(migration)
+
+def query_first_user(conn):
+    return conn.execute("SELECT email, full_name, phone_number FROM users").fetchone()
+    


### PR DESCRIPTION
Agrego:
* uso de SQLAlchemy, que por ahora convive con la conexión directa con pgsql
* pruebas "unitarias" mockeando la BBDD con pytest-pgsql
* unión de login de firebase con registración: ahora si el usuario tiene un claim válido pero no está en la plataforma se lo registra automáticamente
* cambios menores en otros endpoints para empezar a usar el modelo de SQLAlchemy y deprecar métodos de db_functions